### PR TITLE
Enables matrix build

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -27,15 +27,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ## TODO: When OSS is ready, use the following line
-        # plan: ${{fromJSON(needs.ci-enumerate.outputs.plan)}}
-
-        ## TODO: When OSS is ready, delete the following:
-        plan: 
-        - path: "ci/configs/ghc-9.4.8.project"
-          name: "ghc-9.4.8"
-          ghc: "9.4.8"
-          is_head: false
+        plan: ${{fromJSON(needs.ci-enumerate.outputs.plan)}}
       fail-fast: false
     env:
       cabal-version: 3.10.2.0
@@ -122,15 +114,8 @@ jobs:
     continue-on-error: ${{matrix.plan.is_head}}
     strategy:
       matrix:
-        ## TODO: When OSS is ready, use the following line
-        # plan: ${{fromJSON(needs.ci-enumerate.outputs.plan)}}
+        plan: ${{fromJSON(needs.ci-enumerate.outputs.plan)}}
 
-        ## TODO: When OSS is ready, delete the following:
-          plan: 
-            - path: "ci/configs/ghc-9.4.8.project"
-              name: "ghc-9.4.8"
-              ghc: "9.4.8"
-              is_head: false
       fail-fast: false
     env:
       cabal: 3.10.1.0
@@ -207,5 +192,5 @@ jobs:
     - uses: haskell-actions/setup@v2
       with:
         cabal-version: 3.10.2.0
-        ghc-version: 9.4.8
+        ghc-version: latest
     - run: cabal check

--- a/README.md
+++ b/README.md
@@ -10,6 +10,38 @@ See [CONTRIBUTING.md][CONTRIBUTING] for more details.
 
 [CONTRIBUTING]: ./CONTRIBUTING.md
 
+## Matrix Build
+
+To add/remove a specific ghc version to/from the tested versions, you can just add/remove cabal's freeze file as `ci/configs/ghc-X.X.X.project` and add the following to the header:
+
+```cabal
+import: ../../cabal.project
+-- FIXME: Use Appropriate timestamp for index-state
+index-state: hackage.haskell.org 2024-02-05T22:44:18Z
+```
+
+Note that the actual value of `index-state` should be sufficiently new.
+
+Except this, no modification to Action worklow file is needed in general.
+The following is the example command to add the `ghc-9.8.1` with the most recent Stackage Nightly:
+
+```bash
+curl --location https://www.stackage.org/nightly/cabal.config > ./ci/configs/ghc-9.8.1.project
+cat <<EOF >>./ci/configs/ghc-9.8.1.project
+import: ../../cabal.project
+-- FIXME: Use an appropriate timestamp for index-state
+index-state: hackage.haskell.org 2024-02-05T22:44:18Z
+EOF
+```
+
+Note that we might have to edit `with-compiler` stanza of the downloaded freeze file when you want to test GHC version different from Stackage's default version.
+
+If you want to test some breeding-edge version of GHC but to allow failure, name freeze file as `ghc-X.X.X-head.project`.
+
+```bash
+curl --location https://www.stackage.org/nightly/cabal.config > ./ci/configs/ghc-9.10.1-head.project
+```
+
 ## Copyright
 
 2024 (c) DeepFlow, Inc.

--- a/ci/configs/ghc-9.2.8.project
+++ b/ci/configs/ghc-9.2.8.project
@@ -7,7 +7,7 @@
 -- remote-repo: stackage-lts-20.26:http://www.stackage.org/lts-20.26
 import: ../../cabal.project
 with-compiler: ghc-9.2.8
-index-state: hackage.haskell.org 2024-02-05T22:44:18Z
+index-state: hackage.haskell.org 2024-03-05T05:41:26Z
 constraints: abstract-deque ==0.3,
              abstract-deque-tests ==0.3,
              abstract-par ==0.3.3,

--- a/ci/configs/ghc-9.4.8.project
+++ b/ci/configs/ghc-9.4.8.project
@@ -6,7 +6,7 @@
 -- To only use tested packages, uncomment the following line:
 -- remote-repo: stackage-lts-21.25:http://www.stackage.org/lts-21.25
 import: ../../cabal.project
-index-state: hackage.haskell.org 2024-02-05T22:44:18Z
+index-state: hackage.haskell.org 2024-03-05T05:41:26Z
 with-compiler: ghc-9.4.8
 constraints: abstract-deque ==0.3,
              abstract-deque-tests ==0.3,

--- a/ci/configs/ghc-9.6.4.project
+++ b/ci/configs/ghc-9.6.4.project
@@ -6,7 +6,7 @@
 -- To only use tested packages, uncomment the following line:
 -- remote-repo: stackage-lts-22.12:http://www.stackage.org/lts-22.12
 import: ../../cabal.project
-index-state: hackage.haskell.org 2024-02-05T22:44:18Z
+index-state: hackage.haskell.org 2024-03-05T05:41:26Z
 with-compiler: ghc-9.6.4
 constraints: abstract-deque ==0.3,
              abstract-deque-tests ==0.3,

--- a/ci/configs/ghc-9.8.2.project
+++ b/ci/configs/ghc-9.8.2.project
@@ -6,8 +6,8 @@
 -- To only use tested packages, uncomment the following line:
 -- remote-repo: stackage-nightly-2024-02-28:http://www.stackage.org/nightly-2024-02-28
 import: ../../cabal.project
-index-state: hackage.haskell.org 2024-02-05T22:44:18Z
-with-compiler: ghc-9.8.1
+index-state: hackage.haskell.org 2024-03-05T05:41:26Z
+with-compiler: ghc-9.8.2
 constraints: abstract-deque ==0.3,
              abstract-deque-tests ==0.3,
              abstract-par ==0.3.3,

--- a/ci/scripts/collect-bins.sh
+++ b/ci/scripts/collect-bins.sh
@@ -11,6 +11,9 @@ BENCHS="${DEST}"/benchs
 BENCHS_LIST="${DEST}"/benchs.list
 set -x
 mkdir -p "${TESTS}" "${BENCHS}" "${EXES}"
+touch "${TESTS_LIST}"
+touch "${EXES_LIST}"
+touch "${BENCHS_LIST}"
 set +x
 
 echo "[*] Setting-up cabal-plan"


### PR DESCRIPTION
This enables a matrix build for GHC 9.2, 9.4, 9.6, and 9.8. Closes #1.