### PR TITLE
fix: updates org name

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ If you use VSCode, it is recommended to install the following extensions (as inc
 All the source code (except `Setup.hs`) MUST be formatted with [Fourmolu][fourmolu].
 HLS supports fourmolu as a formatter, so we strongly recommend to use HLS and enable `Format on Save` in your editor.
 
-[issue]: https://github.com/deepflowinc/cmark-combinators/issues
-[pulls]: https://github.com/deepflowinc/cmark-combinators/pulls
+[issue]: https://github.com/deepflowinc-oss/cmark-combinators/issues
+[pulls]: https://github.com/deepflowinc-oss/cmark-combinators/pulls
 [fourmolu]: https://github.com/fourmolu/fourmolu
 [HLS]: https://github.com/haskell/haskell-language-server
 

--- a/cmark-combinators.cabal
+++ b/cmark-combinators.cabal
@@ -1,16 +1,16 @@
 cabal-version: 2.2
 
--- This file has been generated from package.yaml by hpack version 0.35.2.
+-- This file has been generated from package.yaml by hpack version 0.36.0.
 --
 -- see: https://github.com/sol/hpack
 
 name:           cmark-combinators
 version:        0.1.0.0
 synopsis:       A utility to generate well-formed CommonMark, thin wrapper around cmark package.
-description:    Please see the README on GitHub at <https://github.com/deepflowinc/cmark-combinators#readme>
+description:    Please see the README on GitHub at <https://github.com/deepflowinc-oss/cmark-combinators#readme>
 category:       Text
-homepage:       https://github.com/deepflowinc/cmark-combinators#readme
-bug-reports:    https://github.com/deepflowinc/cmark-combinators/issues
+homepage:       https://github.com/deepflowinc-oss/cmark-combinators#readme
+bug-reports:    https://github.com/deepflowinc-oss/cmark-combinators/issues
 author:         DeepFlow, Inc.
 maintainer:     DeepFlow, Inc.
 copyright:      2024 (c) DeepFlow, Inc.
@@ -28,7 +28,7 @@ extra-source-files:
 
 source-repository head
   type: git
-  location: https://github.com/deepflowinc/cmark-combinators
+  location: https://github.com/deepflowinc-oss/cmark-combinators
 
 library
   exposed-modules:

--- a/package.yaml
+++ b/package.yaml
@@ -1,6 +1,6 @@
 name:                cmark-combinators
 version:             0.1.0.0
-github:              "deepflowinc/cmark-combinators"
+github:              "deepflowinc-oss/cmark-combinators"
 license:             BSD-3-Clause
 author:              "DeepFlow, Inc."
 maintainer:          "DeepFlow, Inc."
@@ -24,7 +24,7 @@ category:            Text
 # To avoid duplicated efforts in documentation and dealing with the
 # complications of embedding Haddock markup inside cabal files, it is
 # common to point users to the README.md file.
-description:         Please see the README on GitHub at <https://github.com/deepflowinc/cmark-combinators#readme>
+description:         Please see the README on GitHub at <https://github.com/deepflowinc-oss/cmark-combinators#readme>
 
 dependencies:
 - base >= 4.7 && < 5


### PR DESCRIPTION
This PR updates orgname to `deepflowinc-oss`